### PR TITLE
Added the Background Keyword and Examples keyword for Scenario Outlines.

### DIFF
--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Gherkin Viewer",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "manifest_version": 2,
   "description": "Gherkin syntax highlighter for viewing cucumber feature files.",
   "short_name": "GherkView",

--- a/ext/src/inject/inject.js
+++ b/ext/src/inject/inject.js
@@ -21,6 +21,11 @@ for (i = 0; i < lines; i++)
         //Format the Feature Line
         formatLine(body[i], 'Feature:', 'feature', true);
     }
+    else if (body[i].indexOf('Background:') > -1)
+    {
+        //Format the Background Line
+        formatLine(body[i], 'Background:', 'scenario', false);
+    }
     else if (body[i].indexOf('Scenario:') > -1)
     {
         //Format the Scenario Line
@@ -35,6 +40,11 @@ for (i = 0; i < lines; i++)
     {
         //Format the Scenarios Line
         formatLine(body[i], 'Scenarios:', 'scenario', false);
+    }
+    else if (body[i].indexOf('Examples:') > -1)
+    {
+        //Format the Scenario Line
+        formatLine(body[i], 'Examples:', 'scenario', false);
     }
     else if (body[i].indexOf('Given ') > -1)
     {

--- a/test/ViewFeatures.feature
+++ b/test/ViewFeatures.feature
@@ -13,10 +13,10 @@ Feature: View a feature file
     Then the <keyword> will be <font> and <colour>
 
     Examples:
-      | keyword      | font  | colour  |
-      |  Background: |  H1   |  Blue   |
-      |  Scenario:   |  H1   |  Red    |
-      |  Given       |  H1   |  Red    |
+      | keyword       | font  | colour  |
+      | 'Background'  |  H1   |  Blue   |
+      | 'Scenario'    |  H1   |  Red    |
+      | 'Given'       |  H1   |  Red    |
 
   Scenario: ensure scenario outlines are formatted
     Given a Scenario Outline is included in the feature file


### PR DESCRIPTION
Added keywords Background and Example, just using the same highlighting as Scenario for the time being.
